### PR TITLE
Use block.chainid instead of assembly code.

### DIFF
--- a/contracts/Dependencies/ERC20Permit.sol
+++ b/contracts/Dependencies/ERC20Permit.sol
@@ -17,11 +17,6 @@ abstract contract ERC20Permit is ERC20, IERC2612Permit {
 	bytes32 public immutable DOMAIN_SEPARATOR;
 
 	constructor() {
-		uint256 chainID;
-		assembly {
-			chainID := chainid()
-		}
-
 		DOMAIN_SEPARATOR = keccak256(
 			abi.encode(
 				keccak256(
@@ -29,7 +24,7 @@ abstract contract ERC20Permit is ERC20, IERC2612Permit {
 				),
 				keccak256(bytes(name())),
 				keccak256(bytes("1")), // Version
-				chainID,
+				block.chainid,
 				address(this)
 			)
 		);
@@ -68,11 +63,5 @@ abstract contract ERC20Permit is ERC20, IERC2612Permit {
 	 */
 	function nonces(address owner) public view override returns (uint256) {
 		return _nonces[owner].current();
-	}
-
-	function chainId() public view returns (uint256 chainID) {
-		assembly {
-			chainID := chainid()
-		}
 	}
 }

--- a/contracts/TestContracts/DebtTokenTester.sol
+++ b/contracts/TestContracts/DebtTokenTester.sol
@@ -57,9 +57,7 @@ contract DebtTokenTester is DebtToken {
 	}
 
 	function getChainId() external view returns (uint256 chainID) {
-		assembly {
-			chainID := chainid()
-		}
+		chainID = block.chainid;
 	}
 
 	function getDigest(


### PR DESCRIPTION
Closes #70 