### PR TITLE
fix: [A18] - Misspellings/content mistakes in names or comments

### DIFF
--- a/contracts/AdminContract.sol
+++ b/contracts/AdminContract.sol
@@ -22,7 +22,7 @@ contract AdminContract is IAdminContract, ProxyAdmin {
 	uint256 public constant REDEMPTION_BLOCK_DAYS = 14;
 	uint256 public constant MCR_DEFAULT = 1.1 ether; // 110%
 	uint256 public constant CCR_DEFAULT = 1.5 ether; // 150%
-	uint256 public constant PERCENT_DIVISOR_DEFAULT = 100; // dividing by 100 yields 0.5%
+	uint256 public constant PERCENT_DIVISOR_DEFAULT = 100; // dividing by 100 yields 1%
 	uint256 public constant BORROWING_FEE_DEFAULT = (DECIMAL_PRECISION / 1000) * 5; // 0.5%
 	uint256 public constant DEBT_TOKEN_GAS_COMPENSATION_DEFAULT = 30 ether;
 	uint256 public constant MIN_NET_DEBT_DEFAULT = 300 ether;

--- a/contracts/FeeCollector.sol
+++ b/contracts/FeeCollector.sol
@@ -19,7 +19,7 @@ contract FeeCollector is IFeeCollector, OwnableUpgradeable {
 
 	uint256 public constant MIN_FEE_DAYS = 7;
 	uint256 public constant MIN_FEE_FRACTION = 0.038461538 * 1 ether; // (1/26) fee divided by 26 weeks
-	uint256 public constant FEE_EXPIRATION_SECONDS = 175 * 24 * 60 * 60; // ~ 6 months, minus one week (MIN_FEE_DAYS)
+	uint256 public constant FEE_EXPIRATION_SECONDS = 175 * 1 days; // ~ 6 months, minus one week (MIN_FEE_DAYS)
 
 	/** State -------------------------------------------------------------------------------------------------------- */
 
@@ -248,7 +248,7 @@ contract FeeCollector is IFeeCollector, OwnableUpgradeable {
 		uint256 _feeAmount,
 		FeeRecord storage _sRecord
 	) internal {
-		uint256 from = block.timestamp + MIN_FEE_DAYS * 24 * 60 * 60;
+		uint256 from = block.timestamp + MIN_FEE_DAYS * 1 days;
 		uint256 to = from + FEE_EXPIRATION_SECONDS;
 		_sRecord.amount = _feeAmount;
 		_sRecord.from = from;

--- a/contracts/PriceFeed.sol
+++ b/contracts/PriceFeed.sol
@@ -237,7 +237,7 @@ contract PriceFeed is IPriceFeed, OwnableUpgradeable, BaseMath {
 
 		/*
 		 * Use the larger price as the denominator:
-		 * - If price decreased, the percentage deviation is in relation to the the previous price.
+		 * - If price decreased, the percentage deviation is in relation to the previous price.
 		 * - If price increased, the percentage deviation is in relation to the current price.
 		 */
 		uint256 percentDeviation = (maxPrice - minPrice) * DECIMAL_PRECISION / maxPrice;

--- a/contracts/StabilityPool.sol
+++ b/contracts/StabilityPool.sol
@@ -713,7 +713,7 @@ contract StabilityPool is ReentrancyGuardUpgradeable, PoolBase, IStabilityPool {
 		return _getCompoundedStakeFromSnapshots(initialDeposit, depositSnapshots[_depositor]);
 	}
 
-	// Internal function, used to calculcate compounded deposits and compounded stakes.
+	// Internal function, used to calculate compounded deposits and compounded stakes.
 	function _getCompoundedStakeFromSnapshots(uint256 initialStake, Snapshots storage snapshots)
 		internal
 		view


### PR DESCRIPTION
closes #133 