### PR TITLE
reorder usage of "P", which was causing confusion

### DIFF
--- a/contracts/ActivePool.sol
+++ b/contracts/ActivePool.sol
@@ -106,6 +106,22 @@ contract ActivePool is OwnableUpgradeable, ReentrancyGuardUpgradeable, IActivePo
 		return debtTokenBalances[_asset];
 	}
 
+	function increaseDebt(address _collateral, uint256 _amount) external override callerIsBorrowerOpsOrVesselMgr {
+		uint256 newDebt = debtTokenBalances[_collateral] + _amount;
+		debtTokenBalances[_collateral] = newDebt;
+		emit ActivePoolDebtUpdated(_collateral, newDebt);
+	}
+
+	function decreaseDebt(address _asset, uint256 _amount)
+		external
+		override
+		callerIsBorrowerOpsOrStabilityPoolOrVesselMgr
+	{
+		uint256 newDebt = debtTokenBalances[_asset] - _amount;
+		debtTokenBalances[_asset] = newDebt;
+		emit ActivePoolDebtUpdated(_asset, newDebt);
+	}
+
 	// --- Pool functionality ---
 
 	function sendAsset(
@@ -133,22 +149,6 @@ contract ActivePool is OwnableUpgradeable, ReentrancyGuardUpgradeable, IActivePo
 		return (_account == address(defaultPool) ||
 			_account == address(collSurplusPool) ||
 			_account == stabilityPoolAddress);
-	}
-
-	function increaseDebt(address _collateral, uint256 _amount) external override callerIsBorrowerOpsOrVesselMgr {
-		uint256 newDebt = debtTokenBalances[_collateral] + _amount;
-		debtTokenBalances[_collateral] = newDebt;
-		emit ActivePoolDebtUpdated(_collateral, newDebt);
-	}
-
-	function decreaseDebt(address _asset, uint256 _amount)
-		external
-		override
-		callerIsBorrowerOpsOrStabilityPoolOrVesselMgr
-	{
-		uint256 newDebt = debtTokenBalances[_asset] - _amount;
-		debtTokenBalances[_asset] = newDebt;
-		emit ActivePoolDebtUpdated(_asset, newDebt);
 	}
 
 	function receivedERC20(address _asset, uint256 _amount) external override callerIsBorrowerOpsOrDefaultPool {

--- a/contracts/DefaultPool.sol
+++ b/contracts/DefaultPool.sol
@@ -44,6 +44,18 @@ contract DefaultPool is OwnableUpgradeable, IDefaultPool {
 		return debtTokenBalances[_asset];
 	}
 
+	function increaseDebt(address _asset, uint256 _amount) external override callerIsVesselManager {
+		uint256 newDebt = debtTokenBalances[_asset] + _amount;
+		debtTokenBalances[_asset] = newDebt;
+		emit DefaultPoolDebtUpdated(_asset, newDebt);
+	}
+
+	function decreaseDebt(address _asset, uint256 _amount) external override callerIsVesselManager {
+		uint256 newDebt = debtTokenBalances[_asset] - _amount;
+		debtTokenBalances[_asset] = newDebt;
+		emit DefaultPoolDebtUpdated(_asset, newDebt);
+	}
+
 	// --- Pool functionality ---
 
 	function sendAssetToActivePool(address _asset, uint256 _amount) external override callerIsVesselManager {
@@ -62,18 +74,6 @@ contract DefaultPool is OwnableUpgradeable, IDefaultPool {
 
 		emit DefaultPoolAssetBalanceUpdated(_asset, newBalance);
 		emit AssetSent(activePool, _asset, safetyTransferAmount);
-	}
-
-	function increaseDebt(address _asset, uint256 _amount) external override callerIsVesselManager {
-		uint256 newDebt = debtTokenBalances[_asset] + _amount;
-		debtTokenBalances[_asset] = newDebt;
-		emit DefaultPoolDebtUpdated(_asset, newDebt);
-	}
-
-	function decreaseDebt(address _asset, uint256 _amount) external override callerIsVesselManager {
-		uint256 newDebt = debtTokenBalances[_asset] - _amount;
-		debtTokenBalances[_asset] = newDebt;
-		emit DefaultPoolDebtUpdated(_asset, newDebt);
 	}
 
 	// --- 'require' functions ---


### PR DESCRIPTION
Issues 312 and 244 failed to understand that the "P" value was used elsewhere in the code to calculate rewards/gains. While the end result was the same (and therefore cannot be considered a bug or a problem), we needed to either update the documentation or move its usage back to the original place to avoid any future confusion. 