### PR TITLE
Admin contract standardize params

### DIFF
--- a/contracts/AdminContract.sol
+++ b/contracts/AdminContract.sol
@@ -17,21 +17,21 @@ contract AdminContract is IAdminContract, OwnableUpgradeable {
 	// Constants --------------------------------------------------------------------------------------------------------
 
 	string public constant NAME = "AdminContract";
+
 	uint256 public constant DECIMAL_PRECISION = 1 ether;
 	uint256 public constant _100pct = 1 ether; // 1e18 == 100%
-	uint256 public constant REDEMPTION_BLOCK_DAYS = 14;
-	uint256 public constant MCR_DEFAULT = 1.1 ether; // 110%
-	uint256 public constant CCR_DEFAULT = 1.5 ether; // 150%
-	uint256 public constant PERCENT_DIVISOR_DEFAULT = 100; // dividing by 100 yields 1%
-	uint256 public constant BORROWING_FEE_DEFAULT = (DECIMAL_PRECISION / 1000) * 5; // 0.5%
-	uint256 public constant MIN_NET_DEBT_DEFAULT = 300 ether;
-	uint256 public constant REDEMPTION_FEE_FLOOR_DEFAULT = (DECIMAL_PRECISION / 1000) * 5; // 0.5%
-	uint256 public constant MINT_CAP_DEFAULT = 1_000_000 ether; // 1 million
 	uint256 private constant DEFAULT_DECIMALS = 18;
 
-	// State ------------------------------------------------------------------------------------------------------------
+	uint256 public constant BORROWING_FEE_DEFAULT = 0.005 ether; // 0.5%
+	uint256 public constant CCR_DEFAULT = 1.5 ether; // 150%
+	uint256 public constant MCR_DEFAULT = 1.1 ether; // 110%
+	uint256 public constant MIN_NET_DEBT_DEFAULT = 2_000 ether;
+	uint256 public constant MINT_CAP_DEFAULT = 1_000_000 ether; // 1 million GRAI
+	uint256 public constant PERCENT_DIVISOR_DEFAULT = 100; // dividing by 100 yields 1%
+	uint256 public constant REDEMPTION_FEE_FLOOR_DEFAULT = 0.005 ether; // 0.5%
+	uint256 public constant REDEMPTION_BLOCK_TIMESTAMP_DEFAULT = type(uint256).max; // never
 
-	bool public isInitialized;
+	// State ------------------------------------------------------------------------------------------------------------
 
 	address public timelockAddress;
 
@@ -65,7 +65,7 @@ contract AdminContract is IAdminContract, OwnableUpgradeable {
 	}
 
 	modifier onlyTimelock() {
-		if (isInitialized) {
+		if (isSetupInitialized) {
 			if (msg.sender != timelockAddress) {
 				revert AdminContract__OnlyTimelock();
 			}
@@ -108,7 +108,7 @@ contract AdminContract is IAdminContract, OwnableUpgradeable {
 		address _collSurplusPoolAddress,
 		address _priceFeedAddress,
 		address _timelockAddress
-	) external onlyOwner {
+	) external onlyTimelock {
 		require(!isSetupInitialized, "Setup is already initialized");
 		communityIssuance = ICommunityIssuance(_communityIssuanceAddress);
 		activePool = IActivePool(_activePoolAddress);
@@ -123,34 +123,31 @@ contract AdminContract is IAdminContract, OwnableUpgradeable {
 	 * @dev The deployment script will call this function when all initial collaterals have been configured; 
 	 *      after this is set to true, all subsequent config/setters will need to go through the timelocks.
 	 */
-	function setSetupIsInitialized() external onlyOwner {
+	function setSetupIsInitialized() external onlyTimelock {
 		isSetupInitialized = true;
 	}
 
 	function addNewCollateral(
 		address _collateral,
 		uint256 _debtTokenGasCompensation, // the gas compensation is initialized here as it won't be changed
-		uint256 _decimals,
-		bool _isWrapped
-	) external onlyTimelock {
+		uint256 _decimals
+	) external override onlyTimelock {
 		require(collateralParams[_collateral].mcr == 0, "collateral already exists");
-		// for the moment, require collaterals to have 18 decimals
 		require(_decimals == DEFAULT_DECIMALS, "collaterals must have the default decimals");
 		validCollateral.push(_collateral);
 		collateralParams[_collateral] = CollateralParams({
 			decimals: _decimals,
 			index: validCollateral.length - 1,
 			active: false,
-			isWrapped: _isWrapped,
-			mcr: MCR_DEFAULT,
+			borrowingFee: BORROWING_FEE_DEFAULT,
 			ccr: CCR_DEFAULT,
+			mcr: MCR_DEFAULT,
 			debtTokenGasCompensation: _debtTokenGasCompensation,
 			minNetDebt: MIN_NET_DEBT_DEFAULT,
+			mintCap: MINT_CAP_DEFAULT,
 			percentDivisor: PERCENT_DIVISOR_DEFAULT,
-			borrowingFee: BORROWING_FEE_DEFAULT,
 			redemptionFeeFloor: REDEMPTION_FEE_FLOOR_DEFAULT,
-			redemptionBlockTimestamp: 0,
-			mintCap: MINT_CAP_DEFAULT
+			redemptionBlockTimestamp: REDEMPTION_BLOCK_TIMESTAMP_DEFAULT
 		});
 
 		stabilityPool.addCollateralType(_collateral);
@@ -159,21 +156,124 @@ contract AdminContract is IAdminContract, OwnableUpgradeable {
 		emit CollateralAdded(_collateral);
 	}
 
-	// ======= VIEW FUNCTIONS FOR COLLATERAL =======
-
-	function isWrapped(address _collateral) external view returns (bool) {
-		return collateralParams[_collateral].isWrapped;
+	function setCollateralParameters(
+		address _collateral,
+		uint256 borrowingFee,
+		uint256 ccr,
+		uint256 mcr,
+		uint256 minNetDebt,
+		uint256 mintCap,
+		uint256 percentDivisor,
+		uint256 redemptionFeeFloor
+	) public override onlyTimelock {
+		collateralParams[_collateral].active = true;
+		setBorrowingFee(_collateral, borrowingFee);
+		setCCR(_collateral, ccr);
+		setMCR(_collateral, mcr);
+		setMinNetDebt(_collateral, minNetDebt);
+		setMintCap(_collateral, mintCap);
+		setPercentDivisor(_collateral, percentDivisor);
+		setRedemptionFeeFloor(_collateral, redemptionFeeFloor);
 	}
 
-	function isWrappedMany(address[] calldata _collaterals) external view returns (bool[] memory wrapped) {
-		wrapped = new bool[](_collaterals.length);
-		for (uint256 i = 0; i < _collaterals.length; ) {
-			wrapped[i] = collateralParams[_collaterals[i]].isWrapped;
-			unchecked {
-				i++;
-			}
-		}
+	function setIsActive(address _collateral, bool _active) public onlyTimelock {
+		CollateralParams storage collParams = collateralParams[_collateral];
+		collParams.active = _active;
 	}
+
+	function setBorrowingFee(
+		address _collateral,
+		uint256 borrowingFee
+	)
+		public
+		override
+		onlyTimelock
+		safeCheck("Borrowing Fee", _collateral, borrowingFee, 0, 0.1 ether) // 0% - 10%
+	{
+		CollateralParams storage collParams = collateralParams[_collateral];
+		uint256 oldBorrowing = collParams.borrowingFee;
+		collParams.borrowingFee = borrowingFee;
+		emit BorrowingFeeChanged(oldBorrowing, borrowingFee);
+	}
+
+	function setCCR(
+		address _collateral,
+		uint256 newCCR
+	)
+		public
+		override
+		onlyTimelock
+		safeCheck("CCR", _collateral, newCCR, 1 ether, 10 ether) // 100% - 1,000%
+	{
+		CollateralParams storage collParams = collateralParams[_collateral];
+		uint256 oldCCR = collParams.ccr;
+		collParams.ccr = newCCR;
+		emit CCRChanged(oldCCR, newCCR);
+	}
+
+	function setMCR(
+		address _collateral,
+		uint256 newMCR
+	)
+		public
+		override
+		onlyTimelock
+		safeCheck("MCR", _collateral, newMCR, 1.01 ether, 10 ether) // 101% - 1,000%
+	{
+		CollateralParams storage collParams = collateralParams[_collateral];
+		uint256 oldMCR = collParams.mcr;
+		collParams.mcr = newMCR;
+		emit MCRChanged(oldMCR, newMCR);
+	}
+
+	function setMinNetDebt(
+		address _collateral,
+		uint256 minNetDebt
+	) public override onlyTimelock safeCheck("Min Net Debt", _collateral, minNetDebt, 0, 2_000 ether) {
+		CollateralParams storage collParams = collateralParams[_collateral];
+		uint256 oldMinNet = collParams.minNetDebt;
+		collParams.minNetDebt = minNetDebt;
+		emit MinNetDebtChanged(oldMinNet, minNetDebt);
+	}
+
+	function setMintCap(address _collateral, uint256 mintCap) public override onlyTimelock {
+		CollateralParams storage collParams = collateralParams[_collateral];
+		uint256 oldMintCap = collParams.mintCap;
+		collParams.mintCap = mintCap;
+		emit MintCapChanged(oldMintCap, mintCap);
+	}
+
+	function setPercentDivisor(
+		address _collateral,
+		uint256 percentDivisor
+	) public override onlyTimelock safeCheck("Percent Divisor", _collateral, percentDivisor, 2, 200) {
+		CollateralParams storage collParams = collateralParams[_collateral];
+		uint256 oldPercent = collParams.percentDivisor;
+		collParams.percentDivisor = percentDivisor;
+		emit PercentDivisorChanged(oldPercent, percentDivisor);
+	}
+
+	function setRedemptionFeeFloor(
+		address _collateral,
+		uint256 redemptionFeeFloor
+	)
+		public
+		override
+		onlyTimelock
+		safeCheck("Redemption Fee Floor", _collateral, redemptionFeeFloor, 0.001 ether, 0.1 ether) // 0.10% - 10%
+	{
+		CollateralParams storage collParams = collateralParams[_collateral];
+		uint256 oldRedemptionFeeFloor = collParams.redemptionFeeFloor;
+		collParams.redemptionFeeFloor = redemptionFeeFloor;
+		emit RedemptionFeeFloorChanged(oldRedemptionFeeFloor, redemptionFeeFloor);
+	}
+
+	function setRedemptionBlockTimestamp(address _collateral, uint256 _blockTimestamp) public override onlyTimelock {
+		collateralParams[_collateral].redemptionBlockTimestamp = _blockTimestamp;
+		emit RedemptionBlockTimestampChanged(_collateral, _blockTimestamp);
+	}
+
+	// View functions ---------------------------------------------------------------------------------------------------
 
 	function getValidCollateral() external view override returns (address[] memory) {
 		return validCollateral;
@@ -202,118 +302,6 @@ contract AdminContract is IAdminContract, OwnableUpgradeable {
 				i++;
 			}
 		}
-	}
-
-	function setCollateralParameters(
-		address _collateral,
-		uint256 newMCR,
-		uint256 newCCR,
-		uint256 minNetDebt,
-		uint256 percentDivisor,
-		uint256 borrowingFee,
-		uint256 redemptionFeeFloor,
-		uint256 mintCap
-	) public onlyTimelock {
-		collateralParams[_collateral].active = true;
-		setMCR(_collateral, newMCR);
-		setCCR(_collateral, newCCR);
-		setMinNetDebt(_collateral, minNetDebt);
-		setPercentDivisor(_collateral, percentDivisor);
-		setBorrowingFee(_collateral, borrowingFee);
-		setRedemptionFeeFloor(_collateral, redemptionFeeFloor);
-		setMintCap(_collateral, mintCap);
-	}
-
-	function setMCR(address _collateral, uint256 newMCR)
-		public
-		override
-		onlyTimelock
-		safeCheck("MCR", _collateral, newMCR, 1010000000000000000, 10000000000000000000) /// 101% - 1000%
-	{
-		CollateralParams storage collParams = collateralParams[_collateral];
-		uint256 oldMCR = collParams.mcr;
-		collParams.mcr = newMCR;
-		emit MCRChanged(oldMCR, newMCR);
-	}
-
-	function setCCR(address _collateral, uint256 newCCR)
-		public
-		override
-		onlyTimelock
-		safeCheck("CCR", _collateral, newCCR, 1010000000000000000, 10000000000000000000) /// 101% - 1000%
-	{
-		CollateralParams storage collParams = collateralParams[_collateral];
-		uint256 oldCCR = collParams.ccr;
-		collParams.ccr = newCCR;
-		emit CCRChanged(oldCCR, newCCR);
-	}
-
-	function setActive(address _collateral, bool _active) public onlyTimelock {
-		CollateralParams storage collParams = collateralParams[_collateral];
-		collParams.active = _active;
-	}
-
-	function setPercentDivisor(address _collateral, uint256 percentDivisor)
-		public
-		override
-		onlyTimelock
-		safeCheck("Percent Divisor", _collateral, percentDivisor, 2, 200)
-	{
-		CollateralParams storage collParams = collateralParams[_collateral];
-		uint256 oldPercent = collParams.percentDivisor;
-		collParams.percentDivisor = percentDivisor;
-		emit PercentDivisorChanged(oldPercent, percentDivisor);
-	}
-
-	function setBorrowingFee(address _collateral, uint256 borrowingFee)
-		public
-		override
-		onlyTimelock
-		safeCheck("Borrowing Fee Floor", _collateral, borrowingFee, 0, 1000) /// 0% - 10%
-	{
-		CollateralParams storage collParams = collateralParams[_collateral];
-		uint256 oldBorrowing = collParams.borrowingFee;
-		uint256 newBorrowingFee = (DECIMAL_PRECISION / 10000) * borrowingFee;
-		collParams.borrowingFee = newBorrowingFee;
-		emit BorrowingFeeChanged(oldBorrowing, newBorrowingFee);
-	}
-
-	function setMinNetDebt(address _collateral, uint256 minNetDebt)
-		public
-		override
-		onlyTimelock
-		safeCheck("Min Net Debt", _collateral, minNetDebt, 0, 1800 ether)
-	{
-		CollateralParams storage collParams = collateralParams[_collateral];
-		uint256 oldMinNet = collParams.minNetDebt;
-		collParams.minNetDebt = minNetDebt;
-		emit MinNetDebtChanged(oldMinNet, minNetDebt);
-	}
-
-	function setRedemptionFeeFloor(address _collateral, uint256 redemptionFeeFloor)
-		public
-		override
-		onlyTimelock
-		safeCheck("Redemption Fee Floor", _collateral, redemptionFeeFloor, 10, 1000) /// 0.10% - 10%
-	{
-		CollateralParams storage collParams = collateralParams[_collateral];
-		uint256 oldRedemptionFeeFloor = collParams.redemptionFeeFloor;
-		uint256 newRedemptionFeeFloor = (DECIMAL_PRECISION / 10000) * redemptionFeeFloor;
-		collParams.redemptionFeeFloor = newRedemptionFeeFloor;
-		emit RedemptionFeeFloorChanged(oldRedemptionFeeFloor, newRedemptionFeeFloor);
-	}
-
-	function setMintCap(address _collateral, uint256 mintCap) public override onlyTimelock {
-		CollateralParams storage collParams = collateralParams[_collateral];
-		uint256 oldMintCap = collParams.mintCap;
-		uint256 newMintCap = mintCap;
-		collParams.mintCap = newMintCap;
-		emit MintCapChanged(oldMintCap, newMintCap);
-	}
-
-	function setRedemptionBlockTimestamp(address _collateral, uint256 _blockTimestamp) external override onlyTimelock {
-		collateralParams[_collateral].redemptionBlockTimestamp = _blockTimestamp;
-		emit RedemptionBlockTimestampChanged(_collateral, _blockTimestamp);
 	}
 
 	function getMcr(address _collateral) external view override returns (uint256) {

--- a/contracts/Interfaces/IAdminContract.sol
+++ b/contracts/Interfaces/IAdminContract.sol
@@ -7,23 +7,21 @@ import "./IDefaultPool.sol";
 import "./IPriceFeed.sol";
 
 interface IAdminContract {
-
 	// Structs ----------------------------------------------------------------------------------------------------------
 
 	struct CollateralParams {
 		uint256 decimals;
-		uint256 index; //Maps to token address in validCollateral[]
+		uint256 index; // Maps to token address in validCollateral[]
 		bool active;
-		bool isWrapped;
-		uint256 mcr;
+		uint256 borrowingFee;
 		uint256 ccr;
+		uint256 mcr;
 		uint256 debtTokenGasCompensation; // Amount of debtToken to be locked in gas pool on opening vessels
 		uint256 minNetDebt; // Minimum amount of net debtToken a vessel must have
-		uint256 percentDivisor; // dividing by 200 yields 0.5%
-		uint256 borrowingFee;
+		uint256 mintCap;
+		uint256 percentDivisor;
 		uint256 redemptionFeeFloor;
 		uint256 redemptionBlockTimestamp;
-		uint256 mintCap;
 	}
 
 	// Custom Errors ----------------------------------------------------------------------------------------------------
@@ -57,11 +55,17 @@ interface IAdminContract {
 
 	function priceFeed() external view returns (IPriceFeed);
 
-	function addNewCollateral(
+	function addNewCollateral(address _collateral, uint256 _debtTokenGasCompensation, uint256 _decimals) external;
+
+	function setCollateralParameters(
 		address _collateral,
-		uint256 _debtTokenGasCompensation,
-		uint256 _decimals,
-		bool _isWrapped
+		uint256 borrowingFee,
+		uint256 ccr,
+		uint256 mcr,
+		uint256 minNetDebt,
+		uint256 mintCap,
+		uint256 percentDivisor,
+		uint256 redemptionFeeFloor
 	) external;
 
 	function setMCR(address _collateral, uint256 newMCR) external;

--- a/mainnetDeployment/mainnetDeployment.js
+++ b/mainnetDeployment/mainnetDeployment.js
@@ -75,10 +75,9 @@ async function addCollateral(name, address, chainlinkPriceFeedAddress, maxDeviat
 		console.log(`[${name}] NOTICE: collateral has already been added before`)
 	} else {
 		const decimals = 18
-		const isWrapped = false
 		const gasCompensation = th.dec(30, 18)
 		await helper.sendAndWaitForTransaction(
-			coreContracts.adminContract.addNewCollateral(address, gasCompensation, decimals, isWrapped)
+			coreContracts.adminContract.addNewCollateral(address, gasCompensation, decimals)
 		)
 		console.log(`[${name}] Collateral added @ ${address}`)
 	}

--- a/test/gravita/AdminContractTest.js
+++ b/test/gravita/AdminContractTest.js
@@ -14,38 +14,33 @@ contract("AdminContract", async accounts => {
 	let borrowerOperations
 	let erc20
 
-	let MCR
-	let CCR
-	let GAS_COMPENSATION
-	let MIN_NET_DEBT
-	let PERCENT_DIVISOR
 	let BORROWING_FEE
-	let REDEMPTION_FEE_FLOOR
+	let CCR
+	let MCR
+	let MIN_NET_DEBT
 	let MINT_CAP
+	let PERCENT_DIVISOR
+	let REDEMPTION_FEE_FLOOR
 
-	const MCR_SAFETY_MAX = toBN(dec(1000, 18)).div(toBN(100))
-	const MCR_SAFETY_MIN = toBN(dec(101, 18)).div(toBN(100))
+	const MCR_SAFETY_MAX = toBN(dec(10, 18))
+	const MCR_SAFETY_MIN = toBN((1.01e18).toString())
 
-	const CCR_SAFETY_MAX = toBN(dec(1000, 18)).div(toBN(100))
-	const CCR_SAFETY_MIN = toBN(dec(101, 18)).div(toBN(100))
+	const CCR_SAFETY_MAX = toBN(dec(10, 18))
+	const CCR_SAFETY_MIN = toBN(dec(1, 18))
 
 	const PERCENT_DIVISOR_SAFETY_MAX = toBN(200)
 	const PERCENT_DIVISOR_SAFETY_MIN = toBN(2)
 
-	const BORROWING_FEE_SAFETY_MAX = toBN(1000) //10%
+	const BORROWING_FEE_SAFETY_MAX = toBN((0.1e18).toString()) // 10%
 	const BORROWING_FEE_SAFETY_MIN = toBN(0)
 
-	const MIN_NET_DEBT_SAFETY_MAX = toBN(dec(1800, 18))
+	const MIN_NET_DEBT_SAFETY_MAX = toBN(dec(2_000, 18))
 	const MIN_NET_DEBT_SAFETY_MIN = toBN(0)
 
-	const REDEMPTION_FEE_FLOOR_SAFETY_MAX = toBN(1000)
-	const REDEMPTION_FEE_FLOOR_SAFETY_MIN = toBN(10)
+	const REDEMPTION_FEE_FLOOR_SAFETY_MAX = toBN((0.1e18).toString()) // 10%
+	const REDEMPTION_FEE_FLOOR_SAFETY_MIN = toBN((0.001e18).toString()) // 0.1%
 
 	const openVessel = async params => th.openVessel(contracts, params)
-
-	function applyDecimalPrecision(value) {
-		return DECIMAL_PRECISION.div(toBN(10000)).mul(toBN(value.toString()))
-	}
 
 	beforeEach(async () => {
 		const { coreContracts } = await deploymentHelper.deployTestContracts(treasury, accounts.slice(0, 5))
@@ -55,45 +50,44 @@ contract("AdminContract", async accounts => {
 		erc20 = contracts.erc20
 		vesselManager = contracts.vesselManager
 
-		MCR = await adminContract.MCR_DEFAULT()
-		CCR = await adminContract.CCR_DEFAULT()
-		GAS_COMPENSATION = toBN(dec(30, 18))
-		MIN_NET_DEBT = await adminContract.MIN_NET_DEBT_DEFAULT()
-		PERCENT_DIVISOR = await adminContract.PERCENT_DIVISOR_DEFAULT()
 		BORROWING_FEE = await adminContract.BORROWING_FEE_DEFAULT()
-		REDEMPTION_FEE_FLOOR = await adminContract.REDEMPTION_FEE_FLOOR_DEFAULT()
+		CCR = await adminContract.CCR_DEFAULT()
+		MCR = await adminContract.MCR_DEFAULT()
+		MIN_NET_DEBT = await adminContract.MIN_NET_DEBT_DEFAULT()
 		MINT_CAP = await adminContract.MINT_CAP_DEFAULT()
+		PERCENT_DIVISOR = await adminContract.PERCENT_DIVISOR_DEFAULT()
+		REDEMPTION_FEE_FLOOR = await adminContract.REDEMPTION_FEE_FLOOR_DEFAULT()
 	})
 
 	it("Formula Checks: Call every function with default value, Should match default values", async () => {
-		await adminContract.setMCR(ZERO_ADDRESS, "1100000000000000000")
+		await adminContract.setBorrowingFee(ZERO_ADDRESS, (0.005e18).toString())
 		await adminContract.setCCR(ZERO_ADDRESS, "1500000000000000000")
+		await adminContract.setMCR(ZERO_ADDRESS, "1100000000000000000")
+		await adminContract.setMinNetDebt(ZERO_ADDRESS, dec(2_000, 18))
+		await adminContract.setMintCap(ZERO_ADDRESS, dec(1_000_000, 18))
 		await adminContract.setPercentDivisor(ZERO_ADDRESS, 100)
-		await adminContract.setBorrowingFee(ZERO_ADDRESS, 50)
-		await adminContract.setMinNetDebt(ZERO_ADDRESS, dec(300, 18))
-		await adminContract.setRedemptionFeeFloor(ZERO_ADDRESS, 50)
-		await adminContract.setMintCap(ZERO_ADDRESS, dec(1000000, 18))
+		await adminContract.setRedemptionFeeFloor(ZERO_ADDRESS, (0.005e18).toString())
 
-		assert.equal((await adminContract.getMcr(ZERO_ADDRESS)).toString(), MCR)
-		assert.equal((await adminContract.getCcr(ZERO_ADDRESS)).toString(), CCR)
-		assert.equal((await adminContract.getPercentDivisor(ZERO_ADDRESS)).toString(), PERCENT_DIVISOR)
 		assert.equal((await adminContract.getBorrowingFee(ZERO_ADDRESS)).toString(), BORROWING_FEE)
+		assert.equal((await adminContract.getCcr(ZERO_ADDRESS)).toString(), CCR)
+		assert.equal((await adminContract.getMcr(ZERO_ADDRESS)).toString(), MCR)
 		assert.equal((await adminContract.getMinNetDebt(ZERO_ADDRESS)).toString(), MIN_NET_DEBT)
-		assert.equal((await adminContract.getRedemptionFeeFloor(ZERO_ADDRESS)).toString(), REDEMPTION_FEE_FLOOR)
 		assert.equal((await adminContract.getMintCap(ZERO_ADDRESS)).toString(), MINT_CAP)
+		assert.equal((await adminContract.getPercentDivisor(ZERO_ADDRESS)).toString(), PERCENT_DIVISOR)
+		assert.equal((await adminContract.getRedemptionFeeFloor(ZERO_ADDRESS)).toString(), REDEMPTION_FEE_FLOOR)
 	})
 
 	it("Try to edit Parameters as User, Revert Transactions", async () => {
 		await assertRevert(
 			adminContract.setCollateralParameters(
 				ZERO_ADDRESS,
-				MCR,
-				CCR,
-				MIN_NET_DEBT,
-				PERCENT_DIVISOR,
 				BORROWING_FEE,
-				REDEMPTION_FEE_FLOOR,
+				CCR,
+				MCR,
+				MIN_NET_DEBT,
 				MINT_CAP,
+				PERCENT_DIVISOR,
+				REDEMPTION_FEE_FLOOR,
 				{ from: user }
 			)
 		)
@@ -161,14 +155,11 @@ contract("AdminContract", async accounts => {
 	})
 
 	it("setBorrowingFeeFloor: Owner change parameter - Valid SafeCheck", async () => {
-		const expectedMin = applyDecimalPrecision(BORROWING_FEE_SAFETY_MIN)
-		const expectedMax = applyDecimalPrecision(BORROWING_FEE_SAFETY_MAX)
-
 		await adminContract.setBorrowingFee(ZERO_ADDRESS, BORROWING_FEE_SAFETY_MIN)
-		assert.equal(expectedMin.toString(), await adminContract.getBorrowingFee(ZERO_ADDRESS))
+		assert.equal(BORROWING_FEE_SAFETY_MIN.toString(), await adminContract.getBorrowingFee(ZERO_ADDRESS))
 
 		await adminContract.setBorrowingFee(ZERO_ADDRESS, BORROWING_FEE_SAFETY_MAX)
-		assert.equal(expectedMax.toString(), await adminContract.getBorrowingFee(ZERO_ADDRESS))
+		assert.equal(BORROWING_FEE_SAFETY_MAX.toString(), await adminContract.getBorrowingFee(ZERO_ADDRESS))
 	})
 
 	it("setRedemptionFeeFloor: Owner change parameter - Failing SafeCheck", async () => {
@@ -177,105 +168,84 @@ contract("AdminContract", async accounts => {
 	})
 
 	it("setRedemptionFeeFloor: Owner change parameter - Valid SafeCheck", async () => {
-		const expectedMin = applyDecimalPrecision(REDEMPTION_FEE_FLOOR_SAFETY_MIN)
-		const expectedMax = applyDecimalPrecision(REDEMPTION_FEE_FLOOR_SAFETY_MAX)
-
 		await adminContract.setRedemptionFeeFloor(ZERO_ADDRESS, REDEMPTION_FEE_FLOOR_SAFETY_MIN)
-		assert.equal(expectedMin.toString(), await adminContract.getRedemptionFeeFloor(ZERO_ADDRESS))
+		assert.equal(REDEMPTION_FEE_FLOOR_SAFETY_MIN.toString(), await adminContract.getRedemptionFeeFloor(ZERO_ADDRESS))
 
 		await adminContract.setRedemptionFeeFloor(ZERO_ADDRESS, REDEMPTION_FEE_FLOOR_SAFETY_MAX)
-		assert.equal(expectedMax.toString(), await adminContract.getRedemptionFeeFloor(ZERO_ADDRESS))
+		assert.equal(REDEMPTION_FEE_FLOOR_SAFETY_MAX.toString(), await adminContract.getRedemptionFeeFloor(ZERO_ADDRESS))
 	})
 
 	it("setCollateralParameters: Owner change parameter - Failing SafeCheck", async () => {
 		await assertRevert(
 			adminContract.setCollateralParameters(
 				ZERO_ADDRESS,
-				MCR_SAFETY_MAX.add(toBN(1)),
-				CCR,
-				MIN_NET_DEBT,
-				PERCENT_DIVISOR,
-				BORROWING_FEE,
-				REDEMPTION_FEE_FLOOR,
-				MINT_CAP
-			)
-		)
-
-		await assertRevert(
-			adminContract.setCollateralParameters(
-				ZERO_ADDRESS,
-				MCR,
-				CCR_SAFETY_MAX.add(toBN(1)),
-				MIN_NET_DEBT,
-				PERCENT_DIVISOR,
-				BORROWING_FEE,
-				REDEMPTION_FEE_FLOOR,
-				MINT_CAP
-			)
-		)
-
-		await assertRevert(
-			adminContract.setCollateralParameters(
-				ZERO_ADDRESS,
-				MCR,
-				CCR,
-				MIN_NET_DEBT,
-				PERCENT_DIVISOR,
-				BORROWING_FEE,
-				REDEMPTION_FEE_FLOOR,
-				MINT_CAP
-			)
-		)
-
-		await assertRevert(
-			adminContract.setCollateralParameters(
-				ZERO_ADDRESS,
-				MCR,
-				CCR,
-				MIN_NET_DEBT_SAFETY_MAX.add(toBN(1)),
-				PERCENT_DIVISOR,
-				BORROWING_FEE,
-				REDEMPTION_FEE_FLOOR,
-				MINT_CAP
-			)
-		)
-
-		await assertRevert(
-			adminContract.setCollateralParameters(
-				ZERO_ADDRESS,
-				MCR,
-				CCR,
-				MIN_NET_DEBT,
-				PERCENT_DIVISOR_SAFETY_MAX.add(toBN(1)),
-				BORROWING_FEE,
-				REDEMPTION_FEE_FLOOR,
-				MINT_CAP
-			)
-		)
-
-		await assertRevert(
-			adminContract.setCollateralParameters(
-				ZERO_ADDRESS,
-				MCR,
-				CCR,
-				MIN_NET_DEBT,
-				PERCENT_DIVISOR,
 				BORROWING_FEE_SAFETY_MAX.add(toBN(1)),
-				REDEMPTION_FEE_FLOOR,
-				MINT_CAP
+				CCR,
+				MCR,
+				MIN_NET_DEBT,
+				MINT_CAP,
+				PERCENT_DIVISOR,
+				REDEMPTION_FEE_FLOOR
 			)
 		)
-
 		await assertRevert(
 			adminContract.setCollateralParameters(
 				ZERO_ADDRESS,
-				MCR,
-				CCR,
-				MIN_NET_DEBT,
-				PERCENT_DIVISOR,
 				BORROWING_FEE,
-				REDEMPTION_FEE_FLOOR_SAFETY_MAX.add(toBN(1)),
-				MINT_CAP
+				CCR_SAFETY_MAX.add(toBN(1)),
+				MCR,
+				MIN_NET_DEBT,
+				MINT_CAP,
+				PERCENT_DIVISOR,
+				REDEMPTION_FEE_FLOOR
+			)
+		)
+		await assertRevert(
+			adminContract.setCollateralParameters(
+				ZERO_ADDRESS,
+				BORROWING_FEE,
+				CCR,
+				MCR_SAFETY_MAX.add(toBN(1)),
+				MIN_NET_DEBT,
+				MINT_CAP,
+				PERCENT_DIVISOR,
+				REDEMPTION_FEE_FLOOR
+			)
+		)
+		await assertRevert(
+			adminContract.setCollateralParameters(
+				ZERO_ADDRESS,
+				BORROWING_FEE,
+				CCR,
+				MCR,
+				MIN_NET_DEBT_SAFETY_MAX.add(toBN(1)),
+				MINT_CAP,
+				PERCENT_DIVISOR,
+				REDEMPTION_FEE_FLOOR
+			)
+		)
+		await assertRevert(
+			adminContract.setCollateralParameters(
+				ZERO_ADDRESS,
+				BORROWING_FEE,
+				CCR,
+				MCR,
+				MIN_NET_DEBT,
+				MINT_CAP,
+				PERCENT_DIVISOR_SAFETY_MAX.add(toBN(1)),
+				REDEMPTION_FEE_FLOOR
+			)
+		)
+		await assertRevert(
+			adminContract.setCollateralParameters(
+				ZERO_ADDRESS,
+				BORROWING_FEE,
+				CCR,
+				MCR,
+				MIN_NET_DEBT,
+				MINT_CAP,
+				PERCENT_DIVISOR,
+				REDEMPTION_FEE_FLOOR_SAFETY_MAX.add(toBN(1))
 			)
 		)
 	})
@@ -283,10 +253,7 @@ contract("AdminContract", async accounts => {
 	it("openVessel(): Borrowing at zero base rate charges minimum fee with different borrowingFeeFloor", async () => {
 		await adminContract.setBorrowingFee(erc20.address, BORROWING_FEE_SAFETY_MAX)
 
-		assert.equal(
-			applyDecimalPrecision(BORROWING_FEE_SAFETY_MAX).toString(),
-			await adminContract.getBorrowingFee(erc20.address)
-		)
+		assert.equal(BORROWING_FEE_SAFETY_MAX.toString(), await adminContract.getBorrowingFee(erc20.address))
 
 		await openVessel({
 			asset: erc20.address,
@@ -320,4 +287,3 @@ contract("AdminContract", async accounts => {
 })
 
 contract("Reset chain state", async accounts => {})
-

--- a/utils/deploymentHelpers.js
+++ b/utils/deploymentHelpers.js
@@ -143,7 +143,7 @@ class DeploymentHelper {
 			contracts.stabilityPool.address,
 			contracts.collSurplusPool.address,
 			contracts.priceFeedTestnet.address,
-			contracts.shortTimelock.address,
+			contracts.shortTimelock.address
 		)
 
 		await contracts.borrowerOperations.setAddresses(
@@ -211,13 +211,13 @@ class DeploymentHelper {
 			contracts.adminContract.address
 		)
 
-		await contracts.adminContract.addNewCollateral(EMPTY_ADDRESS, dec(30, 18), 18, false)
-		await contracts.adminContract.addNewCollateral(contracts.erc20.address, dec(200, 18), 18, false)
-		await contracts.adminContract.addNewCollateral(contracts.erc20B.address, dec(30, 18), 18, false)
+		await contracts.adminContract.addNewCollateral(EMPTY_ADDRESS, dec(30, 18), 18)
+		await contracts.adminContract.addNewCollateral(contracts.erc20.address, dec(200, 18), 18)
+		await contracts.adminContract.addNewCollateral(contracts.erc20B.address, dec(30, 18), 18)
 
-		await contracts.adminContract.setActive(EMPTY_ADDRESS, true)
-		await contracts.adminContract.setActive(contracts.erc20.address, true)
-		await contracts.adminContract.setActive(contracts.erc20B.address, true)
+		await contracts.adminContract.setIsActive(EMPTY_ADDRESS, true)
+		await contracts.adminContract.setIsActive(contracts.erc20.address, true)
+		await contracts.adminContract.setIsActive(contracts.erc20B.address, true)
 	}
 
 	/**
@@ -258,36 +258,36 @@ class DeploymentHelper {
 		await GRVTContracts.communityIssuance.setWeeklyGrvtDistribution(weeklyReward, { from: treasuryAddress })
 
 		// Set configs (since the tests have been designed with it)
+		const defaultFee = (0.005e18).toString() // 0.5%
 		await coreContracts.adminContract.setCollateralParameters(
 			EMPTY_ADDRESS,
-			"1100000000000000000",
-			"1500000000000000000",
-			dec(300, 18),
-			100,
-			50,
-			50,
-			dec(1000000, 18)
+			defaultFee, // borrowingFee
+			(1.5e18).toString(), // ccr
+			(1.1e18).toString(), // mcr
+			dec(300, 18), // minNetDebt
+			dec(1_000_000, 18), // mintCap
+			100, // percentDivisor
+			defaultFee // redemptionFeeFloor
 		)
-
 		await coreContracts.adminContract.setCollateralParameters(
 			coreContracts.erc20.address,
-			"1100000000000000000",
-			"1500000000000000000",
-			dec(1800, 18),
-			200,
-			50,
-			50,
-			"10000000000000000000000000000"
+			defaultFee, // borrowingFee
+			(1.5e18).toString(), // ccr
+			(1.1e18).toString(), // mcr
+			dec(1_800, 18), // minNetDebt
+			dec(10_000_000_000, 18), // mintCap
+			200, // percentDivisor
+			defaultFee // redemptionFeeFloor
 		)
 		await coreContracts.adminContract.setCollateralParameters(
 			coreContracts.erc20B.address,
-			"1100000000000000000",
-			"1500000000000000000",
-			dec(1800, 18),
-			200,
-			50,
-			50,
-			"10000000000000000000000000000"
+			defaultFee, // borrowingFee
+			(1.5e18).toString(), // ccr
+			(1.1e18).toString(), // mcr
+			dec(1_800, 18), // minNetDebt
+			dec(10_000_000_000, 18), // mintCap
+			200, // percentDivisor
+			defaultFee // redemptionFeeFloor
 		)
 	}
 }

--- a/utils/deploymentHelpers.js
+++ b/utils/deploymentHelpers.js
@@ -215,6 +215,11 @@ class DeploymentHelper {
 		await contracts.adminContract.addNewCollateral(contracts.erc20.address, dec(200, 18), 18)
 		await contracts.adminContract.addNewCollateral(contracts.erc20B.address, dec(30, 18), 18)
 
+		// Redemption are disabled by default; enable them for testing
+		await contracts.adminContract.setRedemptionBlockTimestamp(EMPTY_ADDRESS, 0)
+		await contracts.adminContract.setRedemptionBlockTimestamp(contracts.erc20.address, 0)
+		await contracts.adminContract.setRedemptionBlockTimestamp(contracts.erc20B.address, 0)
+
 		await contracts.adminContract.setIsActive(EMPTY_ADDRESS, true)
 		await contracts.adminContract.setIsActive(contracts.erc20.address, true)
 		await contracts.adminContract.setIsActive(contracts.erc20B.address, true)


### PR DESCRIPTION
- removed isWrapped (unused) from collateralParams
- normalized parameters so they are all 18-digits
- min CCR is now 1 (instead of 1.01)
- default redemptionBlockTimestamp set to infinity
- default minNetDebt changed from 300 to 2,000
- fixed tests to match new values