### PR TITLE
Optimize search for duplicate elements on array

### DIFF
--- a/contracts/Interfaces/IStabilityPool.sol
+++ b/contracts/Interfaces/IStabilityPool.sol
@@ -40,7 +40,7 @@ interface IStabilityPool is IDeposit {
 	error StabilityPool__ActivePoolOnly(address sender, address expected);
 	error StabilityPool__AdminContractOnly(address sender, address expected);
 	error StabilityPool__VesselManagerOnly(address sender, address expected);
-	error StabilityPool__DuplicateElementOnArray();
+	error StabilityPool__ArrayNotInAscendingOrder();
 
 	// --- Functions ---
 

--- a/contracts/StabilityPool.sol
+++ b/contracts/StabilityPool.sol
@@ -565,19 +565,11 @@ contract StabilityPool is ReentrancyGuardUpgradeable, UUPSUpgradeable, GravitaBa
 	}
 
 	/**
-	 * @notice Calculates all the gains earned by the deposit since its last snapshots were taken.
-	 * @param _depositor address of depositor in question
-	 * @return assets, amounts
-	 */
-	function getDepositorGains(address _depositor) internal view returns (address[] memory, uint256[] memory) {
-		return getDepositorGains(_depositor, IAdminContract(adminContract).getValidCollateral());
-	}
-
-	/**
 	 * @notice get gains on each possible asset by looping through
 	 * @dev assets with _getGainFromSnapshots function
 	 * @param initialDeposit Amount of initial deposit
 	 * @param snapshots struct snapshots
+	 * @param _assets ascending ordered array of assets to calculate and claim gains
 	 */
 	function _calculateNewGains(
 		uint256 initialDeposit,
@@ -585,13 +577,11 @@ contract StabilityPool is ReentrancyGuardUpgradeable, UUPSUpgradeable, GravitaBa
 		address[] memory _assets
 	) internal view returns (uint256[] memory amounts) {
 		uint256 assetsLen = _assets.length;
-		// revert if there is a duplicate on the array
+		// asset list must be on ascending order - used to avoid any repeated elements
 		unchecked {
-			for (uint256 i = 0; i < assetsLen; i++) {
-				for (uint256 j = i + 1; j < assetsLen; j++) {
-					if (_assets[i] == _assets[j]) {
-						revert StabilityPool__DuplicateElementOnArray();
-					}
+			for (uint256 i = 1; i < assetsLen; i++) {
+				if (_assets[i] <= _assets[i-1]) {
+					revert StabilityPool__ArrayNotInAscendingOrder();
 				}
 			}
 		}

--- a/test/gravita/StabilityPoolTest.js
+++ b/test/gravita/StabilityPoolTest.js
@@ -921,7 +921,20 @@ contract("StabilityPool", async accounts => {
 				const txPromise = stabilityPool.provideToSP(dec(1_000, 18), [erc20.address, erc20B.address, erc20.address], {
 					from: whale,
 				})
-				await assertRevert(txPromise, "StabilityPool__DuplicateElementOnArray")
+				await assertRevert(txPromise, "StabilityPool__ArrayNotInAscendingOrder")
+			})
+
+			it("provideToSP(): passing asset array in non-ascending order will revert", async () => {
+				await openWhaleVessel(erc20, (icr = 10), (extraDebtTokenAmt = 1_000_000))
+				// first call won't revert as there is no initial deposit
+				await stabilityPool.provideToSP(dec(199_000, 18), [erc20.address, erc20B.address], { from: whale })
+				// correct order
+				await stabilityPool.provideToSP(dec(199_000, 18), [erc20.address, erc20B.address], { from: whale })
+				// incorrect order - should revert
+				const txPromise = stabilityPool.provideToSP(dec(1_000, 18), [erc20B.address, erc20.address], {
+					from: whale,
+				})
+				await assertRevert(txPromise, "StabilityPool__ArrayNotInAscendingOrder")
 			})
 
 			it("provideToSP(): passing wrong address to asset list has no impact", async () => {

--- a/test/gravita/StabilityPoolTest.js
+++ b/test/gravita/StabilityPoolTest.js
@@ -36,6 +36,9 @@ const deploy = async (treasury, mintingAccounts) => {
 	grvtToken = contracts.grvt.grvtToken
 	communityIssuance = contracts.grvt.communityIssuance
 	validCollateral = await adminContract.getValidCollateral()
+
+	// getDepositorGains() expects a sorted collateral array
+	validCollateral = validCollateral.slice(0).sort((a, b) => toBN(a.toLowerCase()).sub(toBN(b.toLowerCase())))
 }
 
 contract("StabilityPool", async accounts => {
@@ -117,6 +120,7 @@ contract("StabilityPool", async accounts => {
 		after(async () => {
 			await network.provider.send("evm_revert", [initialSnapshotId])
 		})
+
 		describe("Providing", async () => {
 			it("provideToSP(): increases the Stability Pool balance", async () => {
 				await _openVessel(erc20, (extraDebtTokenAmt = 200), alice)
@@ -926,12 +930,11 @@ contract("StabilityPool", async accounts => {
 
 			it("provideToSP(): passing asset array in non-ascending order will revert", async () => {
 				await openWhaleVessel(erc20, (icr = 10), (extraDebtTokenAmt = 1_000_000))
-				// first call won't revert as there is no initial deposit
-				await stabilityPool.provideToSP(dec(199_000, 18), [erc20.address, erc20B.address], { from: whale })
 				// correct order
-				await stabilityPool.provideToSP(dec(199_000, 18), [erc20.address, erc20B.address], { from: whale })
+				await stabilityPool.provideToSP(dec(199_000, 18), validCollateral, { from: whale })
 				// incorrect order - should revert
-				const txPromise = stabilityPool.provideToSP(dec(1_000, 18), [erc20B.address, erc20.address], {
+				const validCollateralReverse = validCollateral.slice(0).reverse()
+				const txPromise = stabilityPool.provideToSP(dec(1_000, 18), validCollateralReverse, {
 					from: whale,
 				})
 				await assertRevert(txPromise, "StabilityPool__ArrayNotInAscendingOrder")


### PR DESCRIPTION
Optimize the search for duplicate elements on the assets array

Removed the getDepositorGains(address _depositor) version as it relied on an unordered list provided by the AdminContract. All calls to getDepositorGains will need to provide an ascending-ordered asset list.